### PR TITLE
Picasso caching and loadImageByID function improvements

### DIFF
--- a/ppsdk_android/src/main/java/com/dynepic/ppsdk_android/utils/_PicassoCache.java
+++ b/ppsdk_android/src/main/java/com/dynepic/ppsdk_android/utils/_PicassoCache.java
@@ -1,0 +1,42 @@
+package com.dynepic.ppsdk_android.utils;
+
+import android.content.Context;
+
+import com.dynepic.ppsdk_android.PPManager;
+import com.squareup.picasso.Picasso;
+
+public class _PicassoCache {
+
+    /**
+     * Static Picasso Instance
+     */
+    private static Picasso picassoInstance = null;
+
+    /**
+     * PicassoCache Constructor
+     *
+     * @param context application Context
+     */
+    private _PicassoCache (Context context) {
+        Picasso.Builder builder = new Picasso.Builder(context);
+        picassoInstance = builder.downloader(PPManager.getInstance().imageDownloader()).build();
+    }
+
+    /**
+     * Get Singleton Picasso Instance
+     *
+     * @param context application Context
+     * @return Picasso instance
+     */
+    public static Picasso getPicassoInstance (Context context) {
+
+        if (picassoInstance == null) {
+
+            new _PicassoCache(context);
+            return picassoInstance;
+        }
+
+        return picassoInstance;
+    }
+
+}


### PR DESCRIPTION
_PicassoCache singleton for optimize RAM and using Cache from OKHttp3 library over Picasso library

Improvements for loadImageByID functions to use cache or not, use size or not, use custom callback or not